### PR TITLE
Version based on assembly and version prefix based on build config

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Package NuGet
         run: |
-          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} -o:package ${{ github.ref == 'refs/heads/dev' && '-p:VersionSuffix=alpha' || '' }}
+          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} -o:package ${{ github.ref == 'refs/heads/dev' && '--version-suffix alpha' || '' }}
 
       - name: Push generated package to GitHub registry
         run: |

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Package NuGet
         run: |
-          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} -o:package ${{ github.ref == 'refs/heads/dev' && '--version-suffix alpha' || '' }}
+          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} --include-symbols -o:package
 
       - name: Push generated package to GitHub registry
         run: |

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Package NuGet
         run: |
-          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} -o:package ${{ github.ref == 'refs/heads/dev' && '-p:VersionSuffix=prerelease' || '' }}
+          dotnet pack Lkhsoft.Collections\Lkhsoft.Collections.csproj --configuration ${{ github.ref == 'refs/heads/dev' && 'Debug' || 'Release' }} -o:package ${{ github.ref == 'refs/heads/dev' && '-p:VersionSuffix=alpha' || '' }}
 
       - name: Push generated package to GitHub registry
         run: |
@@ -33,4 +33,4 @@ jobs:
           dotnet nuget push D:\a\Lkhsoft.Collections\Lkhsoft.Collections\package\*.nupkg --source nakira974.github --skip-duplicate
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --verbosity normal

--- a/Lkhsoft.Collections/Lkhsoft.Collections.csproj
+++ b/Lkhsoft.Collections/Lkhsoft.Collections.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.1</Version>
+        <Version>$(AssemblyVersion)</Version>
         <Title>Lkhsoft.Collections</Title>
         <Authors>Maxime Loukhal</Authors>
         <Description>A set of useful collections such as graphs, binary search trees (AVL, Red Black), B-Tree, Trie and others</Description>
@@ -16,14 +16,16 @@
         <PackageIcon>logo.png</PackageIcon>
         <PackageTags>Graphs BST B-Tree Trie</PackageTags>
         <LangVersion>default</LangVersion>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Company>Lkhsoft</Company>
-        <AssemblyVersion>1.0.0</AssemblyVersion>
-        <FileVersion>1.0.0</FileVersion>
+        <AssemblyVersion>1.0.1</AssemblyVersion>
+        <FileVersion>$(AssemblyVersion)</FileVersion>
         <RepositoryType>git</RepositoryType>
         <PackageReleaseNotes>XML and JSON serialization now supported</PackageReleaseNotes>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <Version>$(AssemblyVersion)-alpha</Version>
+    </PropertyGroup>
     <ItemGroup>
       <None Update="logo.png">
         <Pack>True</Pack>


### PR DESCRIPTION
This pull request includes updates to the build and packaging configuration for the `Lkhsoft.Collections` project. Changes include modifications to the `.github/workflows/dotnet.yaml` file to improve the build process and updates to the `Lkhsoft.Collections.csproj` file to better manage versioning and packaging.

Improvements to build process:

* [`.github/workflows/dotnet.yaml`](diffhunk://#diff-59aef793cd565cd278d8cd1e0dff3396db337b9153a9323f9f3b75521c212d6cL28-R36): Added `--include-symbols` to the `dotnet pack` command to include debugging symbols in the package. Removed the `--no-build` option from the `dotnet test` command to ensure tests run on the latest build.

Versioning and packaging updates:

* [`Lkhsoft.Collections/Lkhsoft.Collections.csproj`](diffhunk://#diff-5621a1ccbe646cfbd792c1e2c3efe73621e6330b3a7fd0ffb3071cbac0624b8cL7-R7): Updated the `Version` property to use `$(AssemblyVersion)` instead of a hardcoded version number.
* [`Lkhsoft.Collections/Lkhsoft.Collections.csproj`](diffhunk://#diff-5621a1ccbe646cfbd792c1e2c3efe73621e6330b3a7fd0ffb3071cbac0624b8cL19-R28): Added a new property group to set the version suffix to `-alpha` for debug builds.
* [`Lkhsoft.Collections/Lkhsoft.Collections.csproj`](diffhunk://#diff-5621a1ccbe646cfbd792c1e2c3efe73621e6330b3a7fd0ffb3071cbac0624b8cL19-R28): Removed the `GeneratePackageOnBuild` property to decouple the build and packaging processes.
* [`Lkhsoft.Collections/Lkhsoft.Collections.csproj`](diffhunk://#diff-5621a1ccbe646cfbd792c1e2c3efe73621e6330b3a7fd0ffb3071cbac0624b8cL19-R28): Adjusted the `AssemblyVersion` and `FileVersion` properties to use the same version number.